### PR TITLE
ONEMPERS-120 introduce memory watcher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ target_link_libraries(flutter-launcher-wayland
   ${WAYLAND_CLIENT_LIBRARIES}
   ${WAYLAND_EGL_LIBRARIES}
   ${FLUTTER_ENGINE_LIBRARIES}
+  pthread
 )
 
 install(TARGETS flutter-launcher-wayland DESTINATION bin)

--- a/src/wayland_display.h
+++ b/src/wayland_display.h
@@ -6,6 +6,9 @@
 #pragma once
 
 #include <atomic>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
 #include <unistd.h>
 #include <EGL/egl.h>
 #include <wayland-client.h>
@@ -85,11 +88,22 @@ private:
 
   FlutterEngine engine_ = nullptr;
 
+  std::unique_ptr<std::thread> memory_watcher_thread_;
+  std::string memory_file_path_;
+  std::vector<long> memory_watch_levels_;
+  std::atomic_bool stop_watcher_thread_ = false;
+  std::condition_variable watcher_thread_cv_;
+  std::mutex watcher_thread_mutex_;
+
   bool SetupEGL();
 
   bool SetupEngine(const std::string &bundle_path, const std::vector<std::string> &command_line_args);
 
   bool StopRunning();
+
+  void SetupMemoryWatcher();
+
+  void MemoryWatcherThread();
 
   // key repeat related
   struct {


### PR DESCRIPTION
watch container memory usage & nofity the application via
FlutterEngineNotifyLowMemoryWarning if defined watermark levels
are exceeded.
Configured via env variables:
FLUTTER_LAUNCHER_WAYLAND_USED_MEMORY_FILE_PATH
- path to the file containing current memory usage (like
/sys/fs/cgroup/memory/lxc/FLUTTER/memory.usage_in_bytes)

FLUTTER_LAUNCHER_WAYLAND_MEMORY_WARNING_WATERMARK_BYTES
- comma separated list of warning levels
