### PR TITLE
ONEMPERS-234 port platform task execution loop from glfw embedder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ set(SOURCES
     src/utils.cc
     src/debug.cc
     src/wayland_display.cc
+    src/event_loop.cc
     src/elf.h
     src/macros.h
     src/keys.h
@@ -42,6 +43,7 @@ set(SOURCES
     src/egl_utils.h
     src/debug.h
     src/wayland_display.h
+    src/event_loop.h
 )
 
 ecm_add_wayland_client_protocol(

--- a/src/event_loop.cc
+++ b/src/event_loop.cc
@@ -1,0 +1,103 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "event_loop.h"
+#include <atomic>
+#include <utility>
+#include <climits>
+
+#include "event_loop.h"
+
+#include <atomic>
+#include <utility>
+#include <unistd.h>
+
+namespace flutter {
+
+PlatformEventLoop::PlatformEventLoop(std::thread::id main_thread_id, const TaskExpiredCallback &on_task_expired, int notify_fd)
+    : main_thread_id_(main_thread_id)
+    , on_task_expired_(std::move(on_task_expired))
+    , notify_fd_(notify_fd) {
+}
+
+PlatformEventLoop::~PlatformEventLoop() = default;
+
+bool PlatformEventLoop::RunsTasksOnCurrentThread() const {
+  return std::this_thread::get_id() == main_thread_id_;
+}
+
+uint64_t PlatformEventLoop::ProcessEvents() {
+  std::vector<FlutterTask> expired_tasks;
+
+  // Process expired tasks.
+  {
+    std::lock_guard<std::mutex> lock(task_queue_mutex_);
+    const uint64_t start_processing_time = FlutterEngineGetCurrentTime();
+    while (!task_queue_.empty()) {
+      const auto &top = task_queue_.top();
+      // If this task (and all tasks after this) has not yet expired, there is
+      // nothing more to do. Quit iterating.
+      if (top.fire_time > start_processing_time) {
+        break;
+      }
+
+      // Make a record of the expired task. Do NOT service the task here
+      // because we are still holding onto the task queue mutex. We don't want
+      // other threads to block on posting tasks onto this thread till we are
+      // done processing expired tasks.
+      expired_tasks.push_back(task_queue_.top().task);
+
+      // Remove the tasks from the delayed tasks queue.
+      task_queue_.pop();
+    }
+  }
+
+  // Fire expired tasks.
+  {
+    // Flushing tasks here without holing onto the task queue mutex.
+    for (const auto &task : expired_tasks) {
+      on_task_expired_(&task);
+    }
+  }
+
+  // return timestamp of next event or 0 if none
+  {
+    std::lock_guard<std::mutex> lock(task_queue_mutex_);
+    if (task_queue_.empty()) {
+      return 0;
+    } else {
+      return task_queue_.top().fire_time;
+    }
+  }
+}
+
+void PlatformEventLoop::PostTask(FlutterTask flutter_task, uint64_t flutter_target_time_nanos) {
+  static std::atomic<uint64_t> sGlobalTaskOrder(0);
+
+  Task task;
+  task.order     = ++sGlobalTaskOrder;
+  task.fire_time = flutter_target_time_nanos;
+  task.task      = flutter_task;
+
+  {
+    std::lock_guard<std::mutex> lock(task_queue_mutex_);
+    task_queue_.push(task);
+
+    // Make sure the queue mutex is unlocked before waking up the loop. In case
+    // the wake causes this thread to be descheduled for the primary thread to
+    // process tasks, the acquisition of the lock on that thread while holding
+    // the lock here momentarily till the end of the scope is a pessimization.
+  }
+  Wake();
+}
+
+void PlatformEventLoop::Wake() {
+  ssize_t ret  = 0;
+  uint64_t val = 1;
+  do {
+    ret = write(notify_fd_, &val, sizeof(val));
+  } while (ret < 0 && errno == EAGAIN);
+}
+
+} // namespace flutter

--- a/src/event_loop.h
+++ b/src/event_loop.h
@@ -1,0 +1,72 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_GLFW_EVENT_LOOP_H_
+#define FLUTTER_SHELL_PLATFORM_GLFW_EVENT_LOOP_H_
+
+#include <chrono>
+#include <deque>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <thread>
+
+#include <flutter_embedder.h>
+
+namespace flutter {
+
+// platform event loop, to handle flutter platform events
+// adapted from flutter engine glfw embedder (flutter/shell/platform/glfw/flutter_glfw.cc)
+class PlatformEventLoop {
+public:
+  using TaskExpiredCallback = std::function<void(const FlutterTask *)>;
+  // Creates an event loop running on the given thread, calling
+  // |on_task_expired| to run tasks.
+  // notify_fd event descriptor will be used to wake up the main thread when events arrive
+  PlatformEventLoop(std::thread::id main_thread_id, const TaskExpiredCallback &on_task_expired, int notify_fd);
+
+  virtual ~PlatformEventLoop();
+
+  // Disallow copy.
+  PlatformEventLoop(const PlatformEventLoop &) = delete;
+  PlatformEventLoop &operator=(const PlatformEventLoop &) = delete;
+
+  // Returns if the current thread is the thread used by this event loop.
+  bool RunsTasksOnCurrentThread() const;
+
+  // processes expired events, and returns next wake up point or 0 if there are no events
+  uint64_t ProcessEvents();
+
+  // Posts a Flutter engine task to the event loop for delayed execution.
+  void PostTask(FlutterTask flutter_task, uint64_t flutter_target_time_nanos);
+
+protected:
+
+  // Wakes the main thread
+  void Wake();
+
+  struct Task {
+    uint64_t order;
+    uint64_t fire_time;
+    FlutterTask task;
+
+    struct Comparer {
+      bool operator()(const Task &a, const Task &b) {
+        if (a.fire_time == b.fire_time) {
+          return a.order > b.order;
+        }
+        return a.fire_time > b.fire_time;
+      }
+    };
+  };
+  std::thread::id main_thread_id_;
+  TaskExpiredCallback on_task_expired_;
+  std::mutex task_queue_mutex_;
+  std::priority_queue<Task, std::deque<Task>, Task::Comparer> task_queue_;
+  int notify_fd_;
+};
+
+} // namespace flutter
+
+#endif // FLUTTER_SHELL_PLATFORM_GLFW_EVENT_LOOP_H_

--- a/src/wayland_display.h
+++ b/src/wayland_display.h
@@ -13,6 +13,7 @@
 #include <gdk/gdk.h>
 #include <xkbcommon/xkbcommon.h>
 #include <flutter_embedder.h>
+#include "event_loop.h"
 
 #include <memory>
 #include <string>
@@ -105,6 +106,10 @@ private:
 
   void CleanupMemoryWatcher();
 
+  bool ConfigurePlatformTaskRunner(FlutterTaskRunnerDescription *task_runner);
+
+  void RunFlutterTask(const FlutterTask *task);
+
   // key repeat related
   struct {
     int32_t repeat_delay_ms_    = 400;
@@ -127,6 +132,11 @@ private:
   ssize_t vSyncSendNotifyData();
   ssize_t vSyncReadNotifyData();
   // }
+
+  struct {
+    std::unique_ptr<PlatformEventLoop> _platform_event_loop;
+    int _platform_event_loop_eventfd = -1;
+  } event_loop_;
 
   FLWAY_DISALLOW_COPY_AND_ASSIGN(WaylandDisplay)
 };


### PR DESCRIPTION
This allows handling of flutter platform events - necessary eg.
for Service Protocol handler registration. The code has been ported
from glfw implementation in flutter engine, in flutter/shell/platform/glfw/
(adapted to use our ppoll based main loop)